### PR TITLE
Put a stop to the E_WARNING about failure to open stream

### DIFF
--- a/src/BaseKit/Command/GenerateHtmlCommand.php
+++ b/src/BaseKit/Command/GenerateHtmlCommand.php
@@ -35,6 +35,7 @@ class GenerateHtmlCommand extends Command
         $twig = new \Twig_Environment($loader);
 
         $outputPath = $input->getArgument('outputPath');
+        $outputPath = realpath($outputPath);
 
         $generator = new \BaseKit\Generator($twig);
         $files = $generator->generate($path, $outputPath);

--- a/src/BaseKit/Generator.php
+++ b/src/BaseKit/Generator.php
@@ -77,6 +77,11 @@ class Generator
 
         $context = array();
 
+        $dataDirectory = $outputPath . '/data';
+        if (!is_dir($dataDirectory)) {
+            mkdir($dataDirectory);
+        }
+
         file_put_contents($outputPath . '/data/commands.json', json_encode($typeahead));
 
         $index = $this->twig->render('commands.twig', $context);


### PR DESCRIPTION
Here's the warning I'm talking about:

``` bash
$ ./bin/console generate:html ~/src/basekit/api/application/configs/guzzle/service.json public/
PHP Warning:  file_put_contents(public//data/commands.json): failed to open stream: No such file or directory in /home/h2s/src/interactive-service-description/src/BaseKit/Generator.php on line 80
Generated 355 files
```
